### PR TITLE
DM-21750: Please release a Docker image with the latest licensed OpenSplice

### DIFF
--- a/develop-env/licensed/Dockerfile
+++ b/develop-env/licensed/Dockerfile
@@ -1,0 +1,28 @@
+ARG image_tag
+
+FROM lsstts/salobj:${image_tag}
+
+USER root
+
+COPY P674-VortexOpenSplice-6.10.3-HDE-x86_64.linux-gcc4.8.2-glibc2.15-installer.run /opt/lsst
+
+WORKDIR /opt/lsst
+
+RUN chmod a+x P674-VortexOpenSplice-6.10.3-HDE-x86_64.linux-gcc4.8.2-glibc2.15-installer.run
+
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    source /home/saluser/repos/ts_sal/setup.env && \
+    ./P674-VortexOpenSplice-6.10.3-HDE-x86_64.linux-gcc4.8.2-glibc2.15-installer.run --mode unattended
+
+WORKDIR /opt/ADLINK/Vortex_v2/Device/VortexOpenSplice/6.10.3/HDE/x86_64.linux/tools/python/src/
+
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    source /home/saluser/repos/ts_sal/setup.env && \
+    pip install --upgrade cython && \
+    python setup.py install
+
+USER saluser
+
+ENV OSPL_HOME=/opt/ADLINK/Vortex_v2/Device/VortexOpenSplice/6.10.3/HDE/x86_64.linux
+
+WORKDIR /home/saluser/


### PR DESCRIPTION
Add Dockerfile that annotates a `lsstts/salobj` image with the licensed version of opensplice. Although it is possible to run the build process I am not sure how to include it in the base image itself as it involves getting the license version and the build system is in a public domain. So I will keep the build separated for now.