### PR TITLE
DM-22016: Deploy xml 4.4 on Tucson Test Stand.

### DIFF
--- a/Compose/TucsonTestStand/atdome_sim_setup.sh
+++ b/Compose/TucsonTestStand/atdome_sim_setup.sh
@@ -10,17 +10,13 @@ echo "#"
 echo "# Loading sal environment"
 . /home/saluser/repos/ts_sal/setup.env
 echo "#"
-echo "# Setting up ATPneumatics Simulator"
+echo "# Setting ATDome Simulator"
 
-setup ts_ATPneumaticsSimulator -t current
-
-
-echo "# Starting ATPneumatics Simulator CSC"
+setup ts_ATDome -t current
 
 while :
     do
-        run_atpneumatics_simulator.py
-        echo "# ATPneumatics Simulator exited. Restarting..."
+        run_atdome.py -s
+        echo "# ATDome Simulator exited. Restarting..."
 done
-
 

--- a/Compose/TucsonTestStand/atdometrajectory_setup.sh
+++ b/Compose/TucsonTestStand/atdometrajectory_setup.sh
@@ -10,17 +10,15 @@ echo "#"
 echo "# Loading sal environment"
 . /home/saluser/repos/ts_sal/setup.env
 echo "#"
-echo "# Setting up ATPneumatics Simulator"
+echo "# Setting up ATDomeTrajectory"
 
-setup ts_ATPneumaticsSimulator -t current
+setup ts_config_attcs -t current
+setup ts_ATDomeTrajectory -t current
 
 
-echo "# Starting ATPneumatics Simulator CSC"
-
+echo "# Starting ATDomeTrajectory CSC"
 while :
     do
-        run_atpneumatics_simulator.py
-        echo "# ATPneumatics Simulator exited. Restarting..."
+        run_atdometrajectory.py
+        echo "# ATDomeTrajectory CSC exited. Restarting..."
 done
-
-

--- a/Compose/TucsonTestStand/atmcs_sim_setup.sh
+++ b/Compose/TucsonTestStand/atmcs_sim_setup.sh
@@ -10,17 +10,13 @@ echo "#"
 echo "# Loading sal environment"
 . /home/saluser/repos/ts_sal/setup.env
 echo "#"
-echo "# Setting up ATPneumatics Simulator"
+echo "# Setting ATMCS Simulator"
 
-setup ts_ATPneumaticsSimulator -t current
-
-
-echo "# Starting ATPneumatics Simulator CSC"
+setup ts_ATMCSSimulator -t current
 
 while :
     do
-        run_atpneumatics_simulator.py
-        echo "# ATPneumatics Simulator exited. Restarting..."
+        run_atmcs_simulator.py
+        echo "# ATMCS Simulator exited. Restarting..."
 done
-
 

--- a/Compose/TucsonTestStand/docker-compose.yml
+++ b/Compose/TucsonTestStand/docker-compose.yml
@@ -3,13 +3,14 @@ version: "3.4"
 services:
 
   queue:
-    image: lsstts/develop-env:salobj4_b30
+    image: lsstts/develop-env:salobj4_b65
     container_name: queue
     environment:
       - LSST_DDS_DOMAIN=auxtelpath
     volumes:
       - /home/saluser/develop:/home/saluser/develop
       - ./queue_setup.sh:/home/saluser/.setup.sh
+      - ./ospl.xml:/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/etc/config/ospl.xml
     stdin_open: true
     tty: true
     networks:
@@ -17,13 +18,14 @@ services:
         ipv4_address: "10.0.100.201"
 
   script:
-    image: lsstts/develop-env:salobj4_b30
+    image: lsstts/develop-env:salobj4_b65
     container_name: script
     environment:
       - LSST_DDS_DOMAIN=auxtelpath
     volumes:
       - /home/saluser/develop:/home/saluser/develop
       - ./request_script_setup.sh:/home/saluser/.setup.sh
+      - ./ospl.xml:/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/etc/config/ospl.xml
     stdin_open: true
     tty: true
     networks:
@@ -31,7 +33,7 @@ services:
         ipv4_address: "10.0.100.202"
 
   atspectrograph:
-    image: lsstts/atspectrograph:DM-19849
+    image: lsstts/atspectrograph:DM-22016
     container_name: atspec
     environment:
       - LSST_DDS_DOMAIN=auxtelpath
@@ -44,6 +46,8 @@ services:
     container_name: watcher
     environment:
       - LSST_DDS_DOMAIN=auxtelpath
+    volumes:
+      - ./ospl.xml:/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/etc/config/ospl.xml
     networks:
       lab-priv-network:
         ipv4_address: "10.0.100.224"
@@ -61,6 +65,106 @@ services:
     stdin_open: true
     tty: true
     entrypoint: ["/home/lsst/.setup.sh"]
+
+  atmcs-sim:
+    image: lsstts/develop-env:salobj4_b65
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+    volumes:
+      - ./atmcs_sim_setup.sh:/home/saluser/.setup.sh
+    stdin_open: true
+    tty: true
+    networks:
+      lab-priv-network:
+        ipv4_address: "10.0.100.216"
+
+  atdome-sim:
+    image: lsstts/develop-env:salobj4_b65
+    container_name: atdome-sim
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+    volumes:
+      - ./atdome_sim_setup.sh:/home/saluser/.setup.sh
+    stdin_open: true
+    tty: true
+    networks:
+      lab-priv-network:
+        ipv4_address: "10.0.100.214"
+
+  atdometrajectory:
+    image: lsstts/develop-env:salobj4_b65
+    container_name: atdometrajectory
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+    volumes:
+      - ./atdometrajectory_setup.sh:/home/saluser/.setup.sh
+    stdin_open: true
+    tty: true
+    networks:
+      lab-priv-network:
+        ipv4_address: "10.0.100.215"
+
+  atpneumatics-sim:
+    image: lsstts/at_pneumatics_sim:DM-22016
+    container_name: atpneumatics-sim
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+    stdin_open: true
+    tty: true
+    networks:
+      lab-priv-network:
+        ipv4_address: "10.0.100.217"
+
+  ataos:
+    image: lsstts/ataos:v1.4.0
+    container_name: ataos
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+    stdin_open: true
+    tty: true
+    networks:
+      lab-priv-network:
+        ipv4_address: "10.0.100.208"
+
+  atptg:
+    image: tiagorib/ptkernel:v1.1rev0_xml4.4.0_sal3.10
+    container_name: atptg
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+    stdin_open: true
+    tty: true
+    networks:
+      lab-priv-network:
+        ipv4_address: "10.0.100.218"
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
+
+  athexapod:
+    image: lsstts/ts_athexapod:v0.2.0_xmlv4.2rev0_sal3.10.0_salobj3.12.0
+    container_name: athexapod
+    volumes:
+      - ./hexapod_tcpConfiguration.yaml:/home/saluser/repos/ts_salobjATHexapod/bin/settingFiles/Test/1/tcpConfiguration.yaml
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+    tty: true
+    networks:
+      lab-priv-network:
+        ipv4_address: "10.0.100.155"
+    depends_on:
+      - hexapod-sim
+
+  hexapod-sim:
+    image: couger01/hexapod_simulator
+    container_name: hexapod-sim
+    networks:
+      lab-priv-network:
+        ipv4_address: "10.0.100.156"
+
+    stdin_open: true
+    tty: true
 
 networks:
   default:

--- a/Compose/TucsonTestStand/docker-compose.yml
+++ b/Compose/TucsonTestStand/docker-compose.yml
@@ -162,9 +162,19 @@ services:
     networks:
       lab-priv-network:
         ipv4_address: "10.0.100.156"
-
     stdin_open: true
     tty: true
+
+  atmonochromator:
+    image: lsstts/monochromator:v0.1.0_sal3.10_salobj3.11.1
+    container_name: atmonochromator
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+    tty: true
+    networks:
+      lab-priv-network:
+        ipv4_address: "10.0.100.205"
+
 
 networks:
   default:

--- a/Compose/TucsonTestStand/hexapod_tcpConfiguration.yaml
+++ b/Compose/TucsonTestStand/hexapod_tcpConfiguration.yaml
@@ -1,0 +1,7 @@
+host: "10.0.100.156"
+port: 50000
+connectionTimeout: 2
+readTimeout: 2
+sendTimeout: 2
+endStr: "endl"
+maxLength: 1024

--- a/Compose/TucsonTestStand/kafka_writers/docker-compose.yaml
+++ b/Compose/TucsonTestStand/kafka_writers/docker-compose.yaml
@@ -2,44 +2,55 @@ version: '3.6'
 
 services:
 
-        salkafka:
-                image: lsstts/salkafka:DM-20991
-                container_name: salkafka
-                environment:
-                        - LSST_DDS_DOMAIN=auxtelpath
-                        - BROKER_IP=140.252.32.142
-                        - BROKER_PORT=31090
-                        - REGISTRY_ADDR=https://test-registry-efd.lsst.codes
-                        - LOG_LEVEL=10
-                        - CSC_LIST=ATCamera ATHeaderService ATArchiver ATMonochromator ATSpectrograph Electrometer Test ScriptQueue Script ATPtg ATMCS ATDomeTrajectory ATPneumatics
-                stdin_open: true
-                tty: true
-                volumes:
-                        - ./ospl_150.xml:/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/etc/config/ospl.xml
-                networks:
-                        bridge:
-                        lab-priv-network:
-                                ipv4_address: "10.0.100.150"
+  salkafka_150:
+    image: lsstts/salkafka:v1.0.0_xmlv4.4.0
+    container_name: salkafka_150
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+      - BROKER_IP=140.252.32.142
+      - BROKER_PORT=31090
+      - REGISTRY_ADDR=https://test-registry-efd.lsst.codes
+      - LOG_LEVEL=10
+      - REPLICATION=3
+      - CSC_LIST=ATHeaderService ATArchiver ATMonochromator ATSpectrograph Electrometer Test ScriptQueue Script ATDome ATDomeTrajectory ATAOS ATPneumatics Watcher ATHexapod
+    stdin_open: true
+    tty: true
+    volumes:
+      - ./ospl_150.xml:/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/etc/config/ospl.xml
+    networks:
+      bridge:
+      lab-priv-network:
+        ipv4_address: "10.0.100.150"
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
 
-        salkafka_watcher:
-                image: lsstts/salkafka:v1.0b1_xmlv4.3.0_RC1
-                container_name: salkafka_watcher
-                environment:
-                        - LSST_DDS_DOMAIN=auxtelpath
-                        - BROKER_IP=140.252.32.142
-                        - BROKER_PORT=31090
-                        - REGISTRY_ADDR=https://test-registry-efd.lsst.codes
-                        - LOG_LEVEL=10
-                        - CSC_LIST=Watcher
-                        - REPLICATION=3
-                stdin_open: true
-                tty: true
-                volumes:
-                        - ./ospl_151.xml:/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/etc/config/ospl.xml
-                networks:
-                        bridge:
-                        lab-priv-network:
-                                ipv4_address: "10.0.100.151"
+  salkafka_151:
+    image: lsstts/salkafka:v1.0.0_xmlv4.4.0
+    container_name: salkafka_151
+    environment:
+      - LSST_DDS_DOMAIN=auxtelpath
+      - BROKER_IP=140.252.32.142
+      - BROKER_PORT=31090
+      - REGISTRY_ADDR=https://test-registry-efd.lsst.codes
+      - LOG_LEVEL=10
+      - REPLICATION=3
+      - CSC_LIST=ATPtg ATMCS ATCamera
+    stdin_open: true
+    tty: true
+    volumes:
+      - ./ospl_151.xml:/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/etc/config/ospl.xml
+    networks:
+      bridge:
+      lab-priv-network:
+        ipv4_address: "10.0.100.151"
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
 
 networks:
   default:

--- a/Compose/TucsonTestStand/ospl.xml
+++ b/Compose/TucsonTestStand/ospl.xml
@@ -1,0 +1,52 @@
+<OpenSplice>
+   <Domain>
+      <Name>ospl_sp_ddsi</Name>
+      <Id>99</Id>
+      <SingleProcess>true</SingleProcess>
+      <Service name="ddsi2">
+         <Command>ddsi2</Command>
+      </Service>
+       <Service name="durability">
+          <Command>durability</Command>
+       </Service>
+   </Domain>
+   <DDSI2Service name="ddsi2">
+      <General>
+         <NetworkInterfaceAddress>AUTO</NetworkInterfaceAddress>
+         <AllowMulticast>true</AllowMulticast>
+         <EnableMulticastLoopback>true</EnableMulticastLoopback>
+         <CoexistWithNativeNetworking>false</CoexistWithNativeNetworking>
+      </General>
+      <Compatibility>
+<!-- see the release notes and/or the OpenSplice configurator on DDSI interoperability -->
+         <StandardsConformance>lax</StandardsConformance>
+<!-- the following one is necessary only for TwinOaks CoreDX DDS compatibility -->
+<!-- <ExplicitlyPublishQosSetToDefault>true</ExplicitlyPublishQosSetToDefault> -->
+      </Compatibility>
+      <Discovery>
+         <ParticipantIndex>none</ParticipantIndex>
+      </Discovery>
+   </DDSI2Service>
+<!-- updated parameters to try and speed up discovery phase -->
+   <DurabilityService name="durability">
+      <Network>
+         <InitialDiscoveryPeriod>0.1</InitialDiscoveryPeriod>
+         <Alignment>
+            <TimeAlignment>false</TimeAlignment>
+            <RequestCombinePeriod>
+               <Initial>1.0</Initial>
+               <Operational>0.1</Operational>
+            </RequestCombinePeriod>
+         </Alignment>
+         <WaitForAttachment maxWaitCount="1">
+            <ServiceName>ddsi2</ServiceName>
+         </WaitForAttachment>
+      </Network>
+      <NameSpaces>
+         <NameSpace name="defaultNamespace">
+            <Partition>*</Partition>
+         </NameSpace>
+         <Policy alignee="Initial" aligner="true" durability="Durable" nameSpace="defaultNamespace"/>
+      </NameSpaces>
+   </DurabilityService>
+</OpenSplice>

--- a/Compose/TucsonTestStand/queue_setup.sh
+++ b/Compose/TucsonTestStand/queue_setup.sh
@@ -23,6 +23,6 @@ setup ts_externalscripts -t current
 
 while :
     do
-        run_script_queue.py 1
+        run_script_queue.py 2
         echo "# Queue exited. Restarting..."
 done

--- a/Compose/TucsonTestStand/request_script_setup.sh
+++ b/Compose/TucsonTestStand/request_script_setup.sh
@@ -23,6 +23,6 @@ setup ts_externalscripts -t current
 
 while :
     do
-        request_script.py 1
+        request_script.py 2
         echo "# Queue exited. Restarting..."
 done

--- a/Compose/lab_jupyter_servers/docker-compose.yml
+++ b/Compose/lab_jupyter_servers/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         ipv4_address: "10.0.100.230"
 
   mreuter:
-    image: lsstts/develop-env:salobj4_b30
+    image: lsstts/develop-env:salobj4_b65
     container_name: atdiag02
     environment:
       - LSST_DDS_DOMAIN=auxtelpath
@@ -37,7 +37,7 @@ services:
         ipv4_address: "10.0.100.204"
 
   patrickingraham:
-    image: lsstts/develop-env:salobj4_b30
+    image: lsstts/develop-env:salobj4_b65
     container_name: atdiag03
     environment:
       - LSST_DDS_DOMAIN=auxtelpath
@@ -55,7 +55,7 @@ services:
         ipv4_address: "10.0.100.219"
 
   ecoughlin:
-    image: lsstts/develop-env:salobj4_b30
+    image: lsstts/develop-env:salobj4_b65
     container_name: atdiag04
     environment:
       - LSST_DDS_DOMAIN=auxtelpath
@@ -73,7 +73,7 @@ services:
         ipv4_address: "10.0.100.220"
 
   tribeiro:
-    image: lsstts/develop-env:salobj4_b30
+    image: lsstts/develop-env:salobj4_b65
     container_name: atdiag05
     environment:
       - LSST_DDS_DOMAIN=auxtelpath
@@ -91,7 +91,7 @@ services:
         ipv4_address: "10.0.100.221"
 
   SashaBrownsberger:
-    image: lsstts/develop-env:salobj4_b30
+    image: lsstts/develop-env:salobj4_b65
     container_name: atdiag06
     environment:
       - LSST_DDS_DOMAIN=auxtelpath
@@ -109,7 +109,7 @@ services:
         ipv4_address: "10.0.100.222"
 
   mondrik:
-    image: lsstts/develop-env:salobj4_b30
+    image: lsstts/develop-env:salobj4_b65
     container_name: atdiag07
     environment:
       - LSST_DDS_DOMAIN=auxtelpath

--- a/at_hexapod/Dockerfile
+++ b/at_hexapod/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsstts/develop-env:20190610_sal3.10.0_salobj3.12.0
+FROM lsstts/develop-env:salobj4_b65
 
 MAINTAINER Andres Anania <aanania@lsst.org>
 
@@ -15,8 +15,8 @@ RUN git clone https://github.com/lsst-ts/pythonFileReader.git -b develop
 RUN git clone https://github.com/lsst-ts/pythonCommunicator.git -b develop
 RUN git clone https://github.com/lsst-ts/ts_salobjATHexapod.git
 
-WORKDIR ${TSREPOS}/ts_xml
-RUN git fetch --all && git checkout "v4.2rev0" -b "v4.2rev0"
+#WORKDIR ${TSREPOS}/ts_xml
+#RUN git fetch --all && git checkout "v4.2rev0" -b "v4.2rev0"
 
 RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
     source /home/saluser/repos/ts_sal/setup.env && \

--- a/at_pneumatics_sim/Dockerfile
+++ b/at_pneumatics_sim/Dockerfile
@@ -1,7 +1,24 @@
-FROM lsstts/develop-env:20190418
+FROM lsstts/develop-env:salobj4_b65
 
 WORKDIR /home/saluser/repos
-RUN git clone https://github.com/lsst-ts/ts_ATPneumaticsSimulator.git && cd ts_ATPneumaticsSimulator && git checkout v0.2.0 && source /opt/lsst/software/stack/loadLSST.bash && source /home/saluser/repos/ts_sal/setup.env && setup sconsUtils -t current && setup ts_sal -t current && setup ts_salobj -t current && make_salpy_libs.py ATPneumatics && eups declare -r . ts_ATPneumaticsSimulator -t $USER && setup ts_ATPneumaticsSimulator -t $USER && scons
+
+RUN git clone https://github.com/lsst-ts/ts_ATPneumaticsSimulator.git
+
+WORKDIR /home/saluser/repos/ts_ATPneumaticsSimulator
+
+RUN git fetch --all && \
+    git checkout "tickets/DM-22016"
+
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    source /home/saluser/repos/ts_sal/setup.env && \
+    setup ts_idl -t current && \
+    make_idl_files.py ATPneumatics
+
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    source /home/saluser/repos/ts_sal/setup.env && \
+    eups declare -r . ts_ATPneumaticsSimulator -t current && \
+    setup ts_ATPneumaticsSimulator -t current && \
+    scons
 
 WORKDIR /home/saluser
 COPY setup.sh /home/saluser/.setup.sh

--- a/ataos/Dockerfile
+++ b/ataos/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsstts/develop-env:salobj4_b38
+FROM lsstts/develop-env:salobj4_b65
 
 LABEL maintainer Tiago Ribeiro <tribeiro@lsst.org>
 
@@ -8,18 +8,14 @@ WORKDIR /home/saluser/repos
 RUN git clone https://github.com/lsst-ts/ts_ataos.git
 
 WORKDIR /home/saluser/repos/ts_ataos
-# RUN git fetch --all && git checkout "tags/v1.2.0" -b "v1.2.0"
-RUN git fetch --all && git checkout "tickets/DM-21161_2"
+RUN git fetch --all && git checkout "tags/v1.4.0" -b "v1.4.0"
+#RUN git fetch --all && git checkout "tickets/DM-21161_2"
 
-WORKDIR /home/saluser/repos/ts_idl
-# RUN git fetch --all && git checkout "tags/v1.2.0" -b "v1.2.0"
-RUN git fetch --all && git checkout "tickets/DM-21161"
-
-WORKDIR /home/saluser/repos/ts_config_attcs
-#RUN git fetch --all && git checkout "v0.1-alpha.4" -b "v0.1-alpha.4"
-#RUN git fetch --all && git checkout "v0.1.0" -b "v0.1.0"
-#RUN git fetch && git checkout "tags/v0.1-alpha.1" -b "v0.1-alpha.1"
-RUN git fetch --all && git checkout "tickets/DM-21161"
+#WORKDIR /home/saluser/repos/ts_config_attcs
+##RUN git fetch --all && git checkout "v0.1-alpha.4" -b "v0.1-alpha.4"
+##RUN git fetch --all && git checkout "v0.1.0" -b "v0.1.0"
+##RUN git fetch && git checkout "tags/v0.1-alpha.1" -b "v0.1-alpha.1"
+#RUN git fetch --all && git checkout "tickets/DM-21161"
 
 WORKDIR /home/saluser
 

--- a/atspectrograph/Dockerfile
+++ b/atspectrograph/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsstts/develop-env:salobj4_b54
+FROM lsstts/develop-env:salobj4_b65
 
 LABEL maintainer Tiago Ribeiro <tribeiro@lsst.org>
 
@@ -9,19 +9,15 @@ RUN git clone https://github.com/lsst-ts/ts_atspec.git && \
     git clone https://github.com/lsst-ts/ts_config_latiss.git
 
 WORKDIR /home/saluser/repos/ts_atspec
-#RUN git fetch --tags && git checkout "tags/v0.2.0" -b "v0.2.0"
-RUN git fetch --tags && git checkout "tickets/DM-19849"
+# RUN git fetch --tags && git checkout "tags/v0.3.0" -b "v0.3.0"
+RUN git fetch --tags && git checkout tickets/DM-22016
 
 WORKDIR /home/saluser/repos/ts_config_latiss
-#RUN git fetch --tags && git checkout "tags/v0.2.0" -b "v0.2.0"
-RUN git fetch --tags && git checkout "tickets/DM-19849"
+RUN git fetch --tags && git checkout "tags/v0.1.0" -b "v0.1.0"
 
 RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
     source /home/saluser/repos/ts_sal/setup.env && \
     eups declare -r . -t current
-
-WORKDIR /home/saluser/repos/ts_xml
-RUN git fetch --all && git checkout "develop" && git pull
 
 WORKDIR /home/saluser
 
@@ -35,7 +31,8 @@ RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
     source /home/saluser/repos/ts_sal/setup.env && \
     setup ts_salobj -t current && \
     setup ts_sal -t current && \
-    eups declare -r . ts_atspectrograph -t current && setup ts_atspectrograph -t current && \
+    eups declare -r . ts_atspectrograph -t current && \
+    setup ts_atspectrograph -t current && \
     scons
 
 WORKDIR /home/saluser/

--- a/deploy-env/conda/Dockerfile
+++ b/deploy-env/conda/Dockerfile
@@ -1,0 +1,45 @@
+FROM centos:7
+
+ARG PYTHON_VERSION=3.7m
+ARG CONDA_VERSION=4.5.4
+
+ENV OSPL_HOME=/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux
+ENV LSST_DDS_DOMAIN=citest
+ENV PYTHON_BUILD_VERSION=${PYTHON_VERSION}
+ENV PYTHON_BUILD_LOCATION=/home/saluser/miniconda3
+#ENV TS_IDL_DIR=/home/saluser/repos/ts_idl/
+#ENV TS_XML_VERSION=${xml_branch}
+
+USER root
+
+RUN adduser -u 1004 -m -s /bin/bash saluser
+
+COPY lsst-ts.repo /tmp/lsst-ts.repo
+
+RUN cat /tmp/lsst-ts.repo >> /etc/yum.conf && \
+    yum install -y wget \
+                   git \
+                   make \
+                   wget \
+                   gcc-c++ \
+                   OpenSpliceDDS-6.9.0-1
+
+USER saluser
+WORKDIR /home/saluser
+
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh && ./miniconda.sh -b
+
+RUN source ~/miniconda3/bin/activate && conda install -c lsstts python=3.7 ts-salobj="v4.5.0" cython ts-idl="0.4.0_v4.4.1"
+
+RUN source ~/miniconda3/bin/activate && \
+    source $OSPL_HOME/release.com && \
+    mkdir dds && \
+    cd dds && \
+    tar xvzf /opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/tools/python-support.tgz && \
+    cd python/src && \
+    python setup.py install
+
+COPY setup.sh /home/saluser/.setup.sh
+
+ENTRYPOINT ["/bin/bash", "--"]
+CMD ["/home/saluser/.setup.sh"]

--- a/deploy-env/conda/Dockerfile
+++ b/deploy-env/conda/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /home/saluser
 
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh && ./miniconda.sh -b
 
-RUN source ~/miniconda3/bin/activate && conda install -c lsstts python=3.7 ts-salobj="v4.5.0" cython ts-idl="0.4.0_v4.4.1"
+RUN source ~/miniconda3/bin/activate && conda install -c lsstts python=3.7 ts-salobj="v5.0.0" cython ts-idl="1.0.0_v4.4.1"
 
 RUN source ~/miniconda3/bin/activate && \
     source $OSPL_HOME/release.com && \

--- a/deploy-env/conda/lsst-ts.repo
+++ b/deploy-env/conda/lsst-ts.repo
@@ -1,0 +1,20 @@
+[lsst-ts]
+name=LSST Telescope and Site packages - $basearch
+baseurl=http://project.lsst.org/ts/lsstrepo
+failovermethod=priority
+enabled=1
+gpgcheck=0
+
+[lsst-ts-debuginfo]
+name=LSST Telescope and Site - $basearch - Debug
+baseurl=http://project.lsst.org/ts/lsstrepo/debug
+failovermethod=priority
+enabled=0
+gpgcheck=0
+
+[lsst-ts-source]
+name=LSST Telescope and Site - $basearch - Source
+baseurl=http://project.lsst.org/ts/lsstrepo/source
+failovermethod=priority
+enabled=0
+gpgcheck=0

--- a/deploy-env/conda/setup.sh
+++ b/deploy-env/conda/setup.sh
@@ -1,0 +1,5 @@
+
+source ~/miniconda3/bin/activate
+source $OSPL_HOME/release.com
+
+/bin/bash --rcfile /home/saluser/.bashrc

--- a/develop-env/conda/Dockerfile
+++ b/develop-env/conda/Dockerfile
@@ -1,33 +1,54 @@
 FROM centos:7
+
 ARG PYTHON_VERSION=3.7m
 ARG CONDA_VERSION=4.5.4
-USER root
-RUN yum install -y mlocate
-RUN adduser -u 1004 -m -s /bin/bash saluser
-RUN yum install -y gcc-c++ make ncurses-libs xterm xorg-x11-fonts-misc java-1.7.0-openjdk-devel maven python-devel swig git tk-devel wget bzip2
-COPY lsst-ts.repo /tmp/lsst-ts.repo
-RUN cat /tmp/lsst-ts.repo >> /etc/yum.conf && yum install -y OpenSpliceDDS-6.9.0-1
-USER saluser
-WORKDIR /home/saluser
+ARG sal_branch=v3.10.0
+ARG xml_branch=v3.10.2
+
 ENV LSST_SDK_INSTALL=/home/saluser/repos/ts_sal
 ENV OSPL_HOME=/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux
 ENV LSST_DDS_DOMAIN=citest
 ENV PYTHON_BUILD_VERSION=${PYTHON_VERSION}
 ENV PYTHON_BUILD_LOCATION=/home/saluser/miniconda3
 ENV TS_IDL_DIR=/home/saluser/repos/ts_idl/
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh && ./miniconda.sh -b
-RUN source ~/miniconda3/bin/activate && conda install -c lsstts python=3.7 ts-salobj cython conda-build anaconda-client
-ARG sal_branch=v3.10.0
-RUN mkdir repos && cd repos && git clone https://github.com/lsst-ts/ts_sal \ 
-    && cd ts_sal && git checkout ${sal_branch} && chmod -R +x bin.src
-RUN source ~/miniconda3/bin/activate && mkdir dds && cd dds && \
-tar xvzf /opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/tools/python-support.tgz && cd python/src \
-&& source ~/repos/ts_sal/setup.env && python setup.py install
-ARG xml_branch=v3.10.2
 ENV TS_XML_VERSION=${xml_branch}
-RUN cd repos && git clone https://github.com/lsst-ts/ts_xml && cd ts_xml \ 
-    && git checkout ${xml_branch}
-RUN cd repos && git clone https://github.com/lsst-ts/ts_idl
+
+USER root
+
+RUN yum install -y mlocate
+RUN adduser -u 1004 -m -s /bin/bash saluser
+RUN yum install -y gcc-c++ make ncurses-libs xterm xorg-x11-fonts-misc java-1.7.0-openjdk-devel maven python-devel swig git tk-devel wget bzip2
+
+COPY lsst-ts.repo /tmp/lsst-ts.repo
+
+RUN cat /tmp/lsst-ts.repo >> /etc/yum.conf && yum install -y OpenSpliceDDS-6.9.0-1
+USER saluser
+WORKDIR /home/saluser
+
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh && ./miniconda.sh -b
+
+RUN source ~/miniconda3/bin/activate && conda install -c lsstts python=3.7 ts-salobj cython conda-build anaconda-client
+
+RUN mkdir repos && cd repos && git clone https://github.com/lsst-ts/ts_sal \
+    && cd ts_sal && git checkout ${sal_branch} && chmod -R +x bin.src
+
+RUN source ~/miniconda3/bin/activate && \
+    mkdir dds && \
+    cd dds && \
+    tar xvzf /opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux/tools/python-support.tgz && \
+    cd python/src && \
+    source ~/repos/ts_sal/setup.env && \
+    python setup.py install
+
+RUN cd repos && \
+    git clone https://github.com/lsst-ts/ts_xml && \
+    cd ts_xml && \
+    git checkout ${xml_branch}
+
+RUN cd repos && \
+    git clone https://github.com/lsst-ts/ts_idl
+
 COPY setup.sh /home/saluser/.setup.sh
+
 ENTRYPOINT ["/bin/bash", "--"]
 CMD ["/home/saluser/.setup.sh"]

--- a/develop-env/conda/Dockerfile
+++ b/develop-env/conda/Dockerfile
@@ -2,8 +2,8 @@ FROM centos:7
 
 ARG PYTHON_VERSION=3.7m
 ARG CONDA_VERSION=4.5.4
-ARG sal_branch=v3.10.0
-ARG xml_branch=v3.10.2
+ARG sal_branch=v4.0.0
+ARG xml_branch=v4.4.1
 
 ENV LSST_SDK_INSTALL=/home/saluser/repos/ts_sal
 ENV OSPL_HOME=/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux
@@ -27,7 +27,7 @@ WORKDIR /home/saluser
 
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh && ./miniconda.sh -b
 
-RUN source ~/miniconda3/bin/activate && conda install -c lsstts python=3.7 ts-salobj cython conda-build anaconda-client
+RUN source ~/miniconda3/bin/activate && conda install -y -c lsstts python=3.7 ts-salobj cython conda-build anaconda-client
 
 RUN mkdir repos && cd repos && git clone https://github.com/lsst-ts/ts_sal \
     && cd ts_sal && git checkout ${sal_branch} && chmod -R +x bin.src
@@ -45,8 +45,8 @@ RUN cd repos && \
     cd ts_xml && \
     git checkout ${xml_branch}
 
-RUN cd repos && \
-    git clone https://github.com/lsst-ts/ts_idl
+#RUN cd repos && \
+#    git clone https://github.com/lsst-ts/ts_idl
 
 COPY setup.sh /home/saluser/.setup.sh
 

--- a/develop-env/conda/setup.sh
+++ b/develop-env/conda/setup.sh
@@ -3,6 +3,6 @@ source ~/miniconda3/bin/activate
 source ~/repos/ts_sal/setup.env
 
 export PATH=$PATH:/home/saluser/repos/ts_sal/bin.src
-export PYTHONPATH=$PYTHONPATH:/home/saluser/repos/ts_idl/python
+#export PYTHONPATH=$PYTHONPATH:/home/saluser/repos/ts_idl/python
 
 /bin/bash --rcfile /home/saluser/.bashrc

--- a/develop-env/conda/setup.sh
+++ b/develop-env/conda/setup.sh
@@ -1,5 +1,8 @@
+
 source ~/miniconda3/bin/activate
 source ~/repos/ts_sal/setup.env
+
 export PATH=$PATH:/home/saluser/repos/ts_sal/bin.src
 export PYTHONPATH=$PYTHONPATH:/home/saluser/repos/ts_idl/python
+
 /bin/bash --rcfile /home/saluser/.bashrc

--- a/efd/salkafka/Dockerfile
+++ b/efd/salkafka/Dockerfile
@@ -1,12 +1,8 @@
-FROM lsstts/develop-env:salobj4_b38
+FROM lsstts/develop-env:salobj4_b61
 
 LABEL maintainer Tiago Ribeiro <tribeiro@lsst.org>
 
 USER saluser
-
-WORKDIR /home/saluser/repos/ts_xml
-#RUN git checkout tags/v3.10.2 -b tags/v3.10.2
-RUN git fetch --all && git checkout "tags/v4.3.0_RC1" -b "v4.3.0_RC1"
 
 WORKDIR /home/saluser/repos/
 
@@ -14,7 +10,7 @@ RUN git clone https://github.com/lsst-ts/ts_salkafka.git
 
 WORKDIR /home/saluser/repos/ts_salkafka
 
-RUN git checkout "tags/v1.0b1" -b "v1.0b1"
+RUN git checkout "tags/v1.0.0" -b "v1.0.0"
 
 RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib &&\
     source /home/saluser/repos/ts_sal/setup.env && \

--- a/efd/salkafka/setup.sh
+++ b/efd/salkafka/setup.sh
@@ -8,7 +8,7 @@ echo "# Loading LSST Stack"
 setup lsst_distrib
 echo "#"
 echo "# Loading sal environment"
-. repos/ts_sal/setup.env
+. /home/saluser/repos/ts_sal/setup.env
 echo "#"
 echo "# Setting up salkafka"
 

--- a/pointing_component/sal3.9_dev/Dockerfile
+++ b/pointing_component/sal3.9_dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsstts/develop-env:salobj4_b38
+FROM lsstts/develop-env:salobj4_b65
 
 WORKDIR /home/saluser/repos
 

--- a/watcher/Dockerfile
+++ b/watcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsstts/develop-env:salobj4_b38
+FROM lsstts/develop-env:salobj4_b65
 
 LABEL maintainer Tiago Ribeiro <tribeiro@lsst.org>
 
@@ -9,6 +9,19 @@ RUN git clone https://github.com/lsst-ts/ts_watcher.git
 
 WORKDIR /home/saluser/repos/ts_watcher
 RUN git fetch --all && git checkout "v0.2.1" -b "v0.2.1"
+
+RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
+    source /home/saluser/repos/ts_sal/setup.env && \
+    setup ts_sal -t current && \
+    make_idl_files.py Watcher
+
+WORKDIR /home/saluser/repos/ts_watcher
+RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
+    source /home/saluser/repos/ts_sal/setup.env && \
+    eups declare -r . ts_watcher -t current && \
+    setup ts_salobj -t current && \
+    setup ts_watcher -t current && \
+    scons
 
 WORKDIR /home/saluser/repos/ts_xml
 RUN git fetch --all && git checkout "v4.1.1" -b "v4.1.1"
@@ -28,26 +41,10 @@ RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
                       ScriptQueue \
                       Script \
                       ATCamera \
-                      ATSpectrograph
-
-WORKDIR /home/saluser/repos/ts_xml
-RUN git fetch --all && git checkout "tags/v4.3.0_RC1" -b "v4.3.0_RC1"
-RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
-    source /home/saluser/repos/ts_sal/setup.env && \
-    setup ts_sal -t current && \
-    make_idl_files.py Watcher
-
-WORKDIR /home/saluser/repos/ts_watcher
-RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
-    source /home/saluser/repos/ts_sal/setup.env && \
-    eups declare -r . ts_watcher -t current && \
-    setup ts_salobj -t current && \
-    setup ts_watcher -t current && \
-    scons
-
-WORKDIR /home/saluser/repos/ts_config_ocs
-RUN git fetch --all && \
-    git checkout "tickets/DM-21742"
+                      ATSpectrograph \
+                      ATArchiver \
+                      ATSpectrograph \
+                      ATHeaderService
 
 WORKDIR /home/saluser/
 COPY setup.sh /home/saluser/.setup.sh

--- a/watcher/Dockerfile
+++ b/watcher/Dockerfile
@@ -43,7 +43,6 @@ RUN source /opt/lsst/software/stack/loadLSST.bash && setup lsst_distrib && \
                       ATCamera \
                       ATSpectrograph \
                       ATArchiver \
-                      ATSpectrograph \
                       ATHeaderService
 
 WORKDIR /home/saluser/


### PR DESCRIPTION
Update jupyter notebook servers on Tucson Test Stand.
Add all components to kafka producers and spread load between two containers.
Limits logging size for atptg.
Deploy ATHexapod simulator.
Add startup script for ATDomeTrajectory.
Use hotfix version of atspec.
Update Tucson Test Stand to deploy xml v4.4.
Update build scripts for all components.
Update build and deployment of kafka producers on the Tucson Test Stand to xml v4.4
Update base image for pointing component.