### PR TITLE
Tickets/dm25294

### DIFF
--- a/Jenkinsfile.base
+++ b/Jenkinsfile.base
@@ -6,6 +6,9 @@ pipeline {
         dockerImageBuild = ""
     }
     parameters {
+        string defaultValue: 'w_latest', description: 'lsstsqre/centos image tag.', name: 'image_tag', trim: false
+        string defaultValue: '1000', description: 'UID of saluser.', name: 'user_id', trim: false
+        string defaultValue: '1000', description: 'GID of saluser.', name: 'group_id', trim: false
         booleanParam defaultValue: false, description: 'Trigger the SalObjContainer build?', name: 'BuildSalobjContainer'
         booleanParam defaultValue: false, description: 'Trigger the DevelopEnvironment build?', name: 'BuildDevEnv'
     }

--- a/Jenkinsfile.base
+++ b/Jenkinsfile.base
@@ -5,7 +5,10 @@ pipeline {
         dockerImageNameBuild = "lsstts/base-env:${image_tag}_b${BUILD_NUMBER}"
         dockerImageBuild = ""
     }
-
+    parameters {
+        booleanParam defaultValue: false, description: 'Trigger the SalObjContainer build?', name: 'BuildSalobjContainer'
+        booleanParam defaultValue: false, description: 'Trigger the DevelopEnvironment build?', name: 'BuildDevEnv'
+    }
     stages {
         stage("Build Docker image") {
             steps {
@@ -22,6 +25,18 @@ pipeline {
                     dockerImageBuild.push()
                     }
                 }
+            }
+        }
+        stage("Trigger the SalObjContainer job") {
+            when {
+                expression {
+                    return params.BuildSalobjContainer
+                }
+            }
+            steps {
+                build job: 'SalObjContainer', parameters: [booleanParam(name: 'BuildDevEnv', value: true), 
+                    booleanParam(name: 'build_develop', value: true), 
+                    booleanParam(name: 'push_tag', value: false)], wait: false
             }
         }
     }

--- a/Jenkinsfile.salobj
+++ b/Jenkinsfile.salobj
@@ -25,7 +25,7 @@ pipeline {
         booleanParam defaultValue: false, description: 'Build master branch for all repos. Ignores All version parameters.', name: 'build_master'
         booleanParam defaultValue: false, description: 'Build develop branch for all repos. Ignores All version parameters.', name: 'build_develop'
         booleanParam defaultValue: true, description: 'Push the tagged build to docker hub?', name: 'push_tag'
-        booleanParam defaultValue: false, description: 'Trigger the Develop Environment build?', name: 'Build_DevEnv'
+        booleanParam defaultValue: false, description: 'Trigger the Develop Environment build?', name: 'BuildDevEnv'
     }
     stages {
         stage("Create docker network.") {
@@ -128,7 +128,7 @@ pipeline {
         stage("Trigger the Develop Environment job") {
             when {
                 expression {
-                    return params.Build_DevEnv
+                    return params.BuildDevEnv
                 }
             }
             steps {

--- a/Jenkinsfile.salobj
+++ b/Jenkinsfile.salobj
@@ -10,7 +10,9 @@ pipeline {
         dockerImageBuild = ""
         base_image_tag = "${base_image_tag}"
     }
-
+    parameters {
+        booleanParam defaultValue: false, description: 'Trigger the Develop Environment build?', name: 'Build_DevEnv'
+    }
     stages {
         stage("Create docker network.") {
             steps {
@@ -106,6 +108,16 @@ pipeline {
                     dockerImageBuild.push()
                     }
                 }
+            }
+        }
+        stage("Trigger the Develop Environment job") {
+            when {
+                expression {
+                    return params.Build_DevEnv
+                }
+            }
+            steps {
+                build job: 'DevelopEnvironment', parameters: [booleanParam(name: 'build_develop', value: true), booleanParam(name: 'push_tag', value: false)], wait: false
             }
         }
     }


### PR DESCRIPTION
Added the infrastructure necessary to run the DevEnv build workflow.  The workflow starts with the Daily RPM job which triggers the BaseDevImage job, controlled by Jenkinsfile.base.  In turn, that triggers the SalObj Container job, controlled by Jenkinsfile.salobj.  Finally, that triggers the DevelopEnvironment job.  No changes were necessary to Jenkinsfile.develop-env.