### PR TITLE
Updated robot/Dockerfile and robot/bash_profile to install python3.7+.

### DIFF
--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -6,7 +6,7 @@ ARG HOME=/home/${USER}
 RUN yum -y update
 RUN yum -y --enablerepo=extras install epel-release && \
 yum -y install git which mlocate wget \
-python36-devel openssl-devel make gcc-c++ bzip2-devel libffi-devel && \
+python37-devel openssl-devel make gcc-c++ bzip2-devel libffi-devel && \
 yum clean all && \
 rm -rf /var/cache/yum
 
@@ -36,6 +36,7 @@ RUN pwd
 
 USER ${USER}
 RUN mkdir bin && mkdir trunk && mkdir Reports
+ENV PATH $PATH:${HOME}/bin:${HOME}/.local/bin
 ENV ROBOTFRAMEWORK_SAL_DIR ${HOME}/trunk/robotframework_SAL
 ENV TS_XML_DIR ${HOME}/trunk/ts_xml
 

--- a/robot/bash_profile
+++ b/robot/bash_profile
@@ -8,7 +8,7 @@ alias ls='ls -GFh'
 alias sudo='sudo -H'
 
 # PATH
-export PATH=$PATH:~/bin
+export PATH=$PATH:~/bin:~/.local/bin
 
 # Custom ENVs
 export XML_HOME=$HOME/trunk/ts_xml
@@ -35,5 +35,5 @@ cyan='\[\033[0;36m\]'
 CYAN='\[\033[1;36m\]'
 NC='\[\033[0m\]'
 
-# Setting PATH for Python 3.6
-alias python3='python3.6'
+# Setting PATH for Python 3.7
+alias python3='python3.7'

--- a/robotsal/Dockerfile
+++ b/robotsal/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsstts/robot:python376
+FROM lsstts/robot:latest
 MAINTAINER Rob Bovill (trekkie2@gmail.com)
 ARG USER=appuser
 ARG HOME=/home/${USER}


### PR DESCRIPTION
Since lsstts/robot:latest has been upgraded to python3.7.6, robotsal can now start from latest instead of python376 tag. Updated Dockerfile accordingly.

Added \${HOME}/bin and \${HOME}/.local/bin to PATH in robot/Dockerfile.