### PR TITLE
DM-24925: Removed the python alias definition from robot/bash_profile.

### DIFF
--- a/robot/bash_profile
+++ b/robot/bash_profile
@@ -35,5 +35,3 @@ cyan='\[\033[0;36m\]'
 CYAN='\[\033[1;36m\]'
 NC='\[\033[0m\]'
 
-# Setting PATH for Python 3.7
-alias python3='python3.7'

--- a/robot/docker_build.sh
+++ b/robot/docker_build.sh
@@ -1,0 +1,3 @@
+docker build --tag lsstts/robot:latest .
+echo -e "\n\nHere's the command to push to image: \n"
+echo -e "docker image push lsstts/robot:latest"

--- a/robotsal/Dockerfile
+++ b/robotsal/Dockerfile
@@ -27,8 +27,9 @@ rpm-build && \
 yum clean all && \
 rm -rf /var/cache/yum
 
-RUN curl -s https://repo-nexus.lsst.org/nexus/repository/ts_yum/master/OpenSpliceDDS-6.9.0-6.x86_64.rpm --output OpenSpliceDDS-6.9.0-6.x86_64.rpm
-RUN yum -y install OpenSpliceDDS-6.9.0-6.x86_64.rpm
+#RUN curl -s https://repo-nexus.lsst.org/nexus/repository/ts_yum/master/OpenSpliceDDS-6.9.0-6.x86_64.rpm --output OpenSpliceDDS-6.9.0-6.x86_64.rpm
+ADD OpenSpliceDDS-6.10.4-5.el7.x86_64.rpm ${HOME}
+RUN yum -y install ${HOME}/OpenSpliceDDS-6.10.4-5.el7.x86_64.rpm
 
 USER ${USER}
 
@@ -37,10 +38,9 @@ COPY --chown=1003:1003 rpmmacros ${HOME}/.rpmmacros
 COPY --chown=0:0 rpmmacros /root/.rpmmacros
 
 ENV LSST_SDK_INSTALL=$HOME/trunk/ts_sal
-ENV OSPL_HOME=/opt/OpenSpliceDDS/V6.9.0/HDE/x86_64.linux
-ENV PYTHON_BUILD_VERSION=3.7m
-ENV PYTHON_BUILD_LOCATION=/usr/local
-ENV LSST_DDS_DOMAIN=citest
+ENV OSPL_HOME=/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux
 
 RUN echo "" >> ${HOME}/.bash_profile && \
 echo 'source $LSST_SDK_INSTALL/setup.env' >> ${HOME}/.bash_profile
+
+ENV LSST_DDS_PARTITION_PREFIX=citest

--- a/robotsal/docker_build.sh
+++ b/robotsal/docker_build.sh
@@ -1,0 +1,3 @@
+docker build --tag ts-dockerhub.lsst.org/robotsal:latest .
+echo -e "\n\nHere's the command to push to image: \n"
+echo -e "docker image push ts-dockerhub.lsst.org/robot:latest"


### PR DESCRIPTION
Installing the licensed version of OpenSplice into the robotsal docker image. RPM is NOT included in this repo, as it is proprietary. Also re-jiggered the EnvVar settings, including moving the LSST_DDS_PARTITION_PREFIX assignment until after sourcing setup.env, to avoid using the default value.

Added docker_build.sh files to both robot and robotsal.